### PR TITLE
fix(SOARHELP-4138): Use a valid data_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Confluence
 
 Publisher: Splunk  
-Connector Version: 3.0.0  
+Connector Version: 3.0.1  
 Product Vendor: Atlassian  
 Product Name: Confluence  
 Product Version Supported (regex): ".\*"  
@@ -11,7 +11,7 @@ Minimum Product Version: 6.3.0
 This app supports a variety of actions for content generation in Confluence
 
 ### Configuration Variables
-The below configuration variables are required for this Connector to operate.  These variables are specified when configuring a Confluence asset in SOAR.
+This table lists the configuration variables required to operate Confluence. These variables are specified when configuring a Confluence asset in Splunk SOAR.
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
@@ -19,7 +19,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **verify_server_cert** |  optional  | boolean | Verify server SSL certificate
 **username** |  required  | string | Username
 **apitoken** |  required  | password | API Token
-**base_path** |  optional  | Base Path | Base Path
+**base_path** |  optional  | string | Base Path
 
 ### Supported Actions  
 [test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using the supplied configuration  

--- a/confluence.json
+++ b/confluence.json
@@ -10,7 +10,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2024 Splunk Inc.",
-    "app_version": "3.0.0",
+    "app_version": "3.0.1",
     "utctime_updated": "2024-11-29T21:14:21.000000Z",
     "package_name": "phantom_confluence",
     "main_module": "confluence_connector.py",
@@ -48,7 +48,7 @@
         },
         "base_path": {
             "description": "Base Path",
-            "data_type": "Base Path",
+            "data_type": "string",
             "required": false,
             "order": 4
         }


### PR DESCRIPTION
Somehow, the latest version of this connector was allowed to ship with a totally broken asset configuration. The 3.0.0 version of this connector cannot even be installed on SOAR, because it has a `data_type` of an asset config param of `Base Path`, which is obviously invalid.

Updated it to `string`